### PR TITLE
feat: notify SchedulerGrain on Successful and failed completion of ImageGeneration

### DIFF
--- a/Grains/usage-tracker/IImageGenerationRequestStatusReceiver.cs
+++ b/Grains/usage-tracker/IImageGenerationRequestStatusReceiver.cs
@@ -2,7 +2,7 @@ using Grains.types;
 
 namespace Grains.usage_tracker;
 
-public interface IImageGenerationRequestStatusReceiver
+public interface IImageGenerationRequestStatusReceiver : Orleans.IGrainWithStringKey
 {
     Task ReportFailedImageGenerationRequestAsync(RequestStatus requestStatus);
     Task ReportCompletedImageGenerationRequestAsync(RequestStatus requestStatus);


### PR DESCRIPTION
- Notify SchedulerGrain from ParentGenerator when the ImageGeneratorGrains are created and request is submitted
- Notify SchedulerGrain. from ImageGenerator when the imageGeneration completed successful or failure
- `IImageGenerationRequestStatusReceiver` interface to inherit `Orleans.IGrainWithStringKey` as it is needed while loading the `SchedulerGrain` with a reference to functions of `IImageGenerationRequestStatusReceiver`