### PR TITLE
feat: content_policy_violation dalle error handling

### DIFF
--- a/Grains/dalle-image-generator/ImageGeneratorGrain.cs
+++ b/Grains/dalle-image-generator/ImageGeneratorGrain.cs
@@ -172,7 +172,13 @@ public class ImageGeneratorGrain : Grain, IImageGeneratorGrain, IDisposable
                 ErrorCode = imageGenerationResponse.ErrorCode
             };
 
-            await schedulerGrain.ReportFailedImageGenerationRequestAsync(requestStatus);
+            if (imageGenerationResponse.ErrorCode == DalleErrorCode.content_policy_violation)
+            {
+                await schedulerGrain.ReportBlockedImageGenerationRequestAsync(requestStatus);
+            } else
+            {
+                await schedulerGrain.ReportFailedImageGenerationRequestAsync(requestStatus);
+            }
         }
 
         // set apiKey to null
@@ -197,10 +203,10 @@ public class ImageGeneratorGrain : Grain, IImageGeneratorGrain, IDisposable
         {
             _imageGenerationState.State.ParentRequestId = parentRequestId;
             _imageGenerationState.State.RequestId = imageRequestId;
-            _imageGenerationState.State.Prompt = prompt;
+            _imageGenerationState.State.Prompt = "I NEED to test how the tool works with extremely simple prompts. DO NOT add any detail, just use it AS-IS: A medium resolution pixel art image of a Somali cat in an upright, bipedal stance, facing directly at the viewer, with Flower Crown, Cap Toe Shoes, Palazzo Jumpsuit, Fuzzy Paw, Shimmering, Teal Feather Wings,and Saddle Stitch Belt.";
             
             // Start the image data generation process
-            var dalleResponse = await RunDalleAsync(prompt);
+            var dalleResponse = await RunDalleAsync( _imageGenerationState.State.Prompt);
 
             _logger.LogInformation($"ImageGeneratorGrain - generatorId: {imageRequestId} , dalleResponse: {dalleResponse}");
 
@@ -364,14 +370,12 @@ public class ImageGeneratorGrain : Grain, IImageGeneratorGrain, IDisposable
                 break;
             case HttpStatusCode.BadRequest:
             {
-                if (dalleErrorObject?.Code == "billing_hard_limit_reached")
+                dalleErrorCodes = dalleErrorObject?.Code switch
                 {
-                    dalleErrorCodes = DalleErrorCode.dalle_billing_quota_exceeded;
-                }
-                else
-                {
-                    dalleErrorCodes = DalleErrorCode.bad_request;
-                }
+                    "billing_hard_limit_reached" => DalleErrorCode.dalle_billing_quota_exceeded,
+                    "content_policy_violation" => DalleErrorCode.content_policy_violation,
+                    _ => DalleErrorCode.bad_request,
+                };
                 break;
             }
             case HttpStatusCode.InternalServerError:

--- a/Grains/dalle-image-generator/ImageGeneratorGrain.cs
+++ b/Grains/dalle-image-generator/ImageGeneratorGrain.cs
@@ -203,10 +203,10 @@ public class ImageGeneratorGrain : Grain, IImageGeneratorGrain, IDisposable
         {
             _imageGenerationState.State.ParentRequestId = parentRequestId;
             _imageGenerationState.State.RequestId = imageRequestId;
-            _imageGenerationState.State.Prompt = "I NEED to test how the tool works with extremely simple prompts. DO NOT add any detail, just use it AS-IS: A medium resolution pixel art image of a Somali cat in an upright, bipedal stance, facing directly at the viewer, with Flower Crown, Cap Toe Shoes, Palazzo Jumpsuit, Fuzzy Paw, Shimmering, Teal Feather Wings,and Saddle Stitch Belt.";
+            _imageGenerationState.State.Prompt = prompt;
             
             // Start the image data generation process
-            var dalleResponse = await RunDalleAsync( _imageGenerationState.State.Prompt);
+            var dalleResponse = await RunDalleAsync(prompt);
 
             _logger.LogInformation($"ImageGeneratorGrain - generatorId: {imageRequestId} , dalleResponse: {dalleResponse}");
 

--- a/Grains/usage-tracker/IImageGenerationRequestStatusReceiver.cs
+++ b/Grains/usage-tracker/IImageGenerationRequestStatusReceiver.cs
@@ -6,4 +6,6 @@ public interface IImageGenerationRequestStatusReceiver : Orleans.IGrainWithStrin
 {
     Task ReportFailedImageGenerationRequestAsync(RequestStatus requestStatus);
     Task ReportCompletedImageGenerationRequestAsync(RequestStatus requestStatus);
+    Task ReportBlockedImageGenerationRequestAsync(RequestStatus requestStatus);
+
 }

--- a/Grains/usage-tracker/SchedulerGrain.cs
+++ b/Grains/usage-tracker/SchedulerGrain.cs
@@ -112,6 +112,14 @@ public class SchedulerGrain : Grain, ISchedulerGrain, IDisposable
         return Task.CompletedTask;
     }
 
+    public Task ReportBlockedImageGenerationRequestAsync(RequestStatus requestStatus)
+    {
+        _logger.LogInformation($"[SchedulerGrain] Report Block Image Generation Request with ID: {requestStatus.RequestId}");
+
+        //TODO this is to be changed
+        return Task.CompletedTask;
+    }
+
     public Task<IReadOnlyDictionary<string, RequestAccountUsageInfo>> GetFailedImageGenerationRequestsAsync()
     {
         return Task.FromResult<IReadOnlyDictionary<string, RequestAccountUsageInfo>>(

--- a/Shared/ImageGenerationConstants.cs
+++ b/Shared/ImageGenerationConstants.cs
@@ -13,4 +13,5 @@ public enum DalleErrorCode
         dalle_engine_unavailable,
         bad_request,
         dalle_billing_quota_exceeded,
+        content_policy_violation
 }


### PR DESCRIPTION
- CopyRight or abusive content in prompts to be handled by ImageGeneratorGrain
- The DalleErrorCode is: `content_policy_violation`

## SchedulerGrain and IImageGenerationRequestStatusReceiver
- new function `ReportBlockedImageGenerationRequestAsync` is added in `IImageGenerationRequestStatusReceiver`
- new function with empty implementation added to `SchedulerGrain`

The implementation of new function in SchedulerBean should handle it to not reprocess the request 

@argfoo-nft 