### PR TITLE
feat: content violation blocker

### DIFF
--- a/Grains/dalle-image-generator/AzureOpenAI/AzureOpenAIImageGenerator.cs
+++ b/Grains/dalle-image-generator/AzureOpenAI/AzureOpenAIImageGenerator.cs
@@ -138,7 +138,7 @@ public class AzureOpenAIImageGenerator : IImageGenerator
     {
         ImageGenerationErrorCode imageGenerationErrorCode;
 
-        if (requestFailedException.ErrorCode == "content_filter")
+        if (requestFailedException.ErrorCode is "content_filter" or "contentFilter")
         {
             imageGenerationErrorCode = ImageGenerationErrorCode.content_violation;
         }

--- a/Grains/dalle-image-generator/DalleOpenAI/DalleOpenAIImageGenerator.cs
+++ b/Grains/dalle-image-generator/DalleOpenAI/DalleOpenAIImageGenerator.cs
@@ -119,6 +119,10 @@ public class DalleOpenAIImageGenerator : IImageGenerator
                 {
                     imageGenerationErrorCode = ImageGenerationErrorCode.billing_quota_exceeded;
                 }
+                else if (dalleOpenAiImageGenerationError?.Code is "content_policy" or "content_policy_violation")
+                {
+                    imageGenerationErrorCode = ImageGenerationErrorCode.content_violation;
+                }
                 else
                 {
                     imageGenerationErrorCode = ImageGenerationErrorCode.bad_request;

--- a/Grains/dalle-image-generator/ImageGeneratorGrain.cs
+++ b/Grains/dalle-image-generator/ImageGeneratorGrain.cs
@@ -285,7 +285,7 @@ public class ImageGeneratorGrain : Grain, IImageGeneratorGrain, IDisposable
 
             //load the Parent Grain and update with status
             var parentGeneratorGrain = GrainFactory.GetGrain<IMultiImageGeneratorGrain>(_imageGenerationState.State.ParentRequestId);
-            await parentGeneratorGrain.NotifyImageGenerationStatus(_imageGenerationState.State.RequestId, ImageGenerationStatus.FailedCompletion, e.Message);
+            await parentGeneratorGrain.NotifyImageGenerationStatus(_imageGenerationState.State.RequestId, ImageGenerationStatus.FailedCompletion, e.Message, ImageGenerationErrorCode.internal_error);
 
             var schedulerGrain = GrainFactory.GetGrain<IImageGenerationRequestStatusReceiver>("SchedulerGrain");
             var requestStatus = new RequestStatus

--- a/Grains/dalle-image-generator/ImageGeneratorGrain.cs
+++ b/Grains/dalle-image-generator/ImageGeneratorGrain.cs
@@ -296,9 +296,9 @@ public class ImageGeneratorGrain : Grain, IImageGeneratorGrain, IDisposable
                 RequestTimestamp = imageGenerationRequestTimestamp,
             };
 
-            if (e is ImageGenerationException)
+            if (e is ImageGenerationException && ((ImageGenerationException) e).ErrorCode == ImageGenerationErrorCode.content_violation)
             {
-                requestStatus.ErrorCode = ((ImageGenerationException) e).ErrorCode;
+                requestStatus.ErrorCode = ImageGenerationErrorCode.content_violation;
                 await schedulerGrain.ReportBlockedImageGenerationRequestAsync(requestStatus);
             }
             else

--- a/Grains/dalle-image-generator/ImageGeneratorState.cs
+++ b/Grains/dalle-image-generator/ImageGeneratorState.cs
@@ -33,4 +33,7 @@ public class ImageGenerationState
     // Now it's nullable and not set by default
     [Id(8)]
     public long? ImageGenerationTimestamp { get; set; }
+    
+    [Id(9)]
+    public ImageGenerationErrorCode? ErrorCode { get; set; }
 }

--- a/Grains/dalle-image-generator/MultiImageGeneratorGrain.cs
+++ b/Grains/dalle-image-generator/MultiImageGeneratorGrain.cs
@@ -222,7 +222,8 @@ public class MultiImageGeneratorGrain : Grain, IMultiImageGeneratorGrain
             return new MultiImageQueryGrainResponse
             {
                 Status = ImageGenerationStatus.FailedCompletion,
-                Errors = errors
+                Errors = errors,
+                ErrorCode = _multiImageGenerationState.State.ErrorCode.ToString()
             };
         }
 

--- a/Grains/dalle-image-generator/MultiImageGeneratorGrain.cs
+++ b/Grains/dalle-image-generator/MultiImageGeneratorGrain.cs
@@ -22,8 +22,56 @@ public class MultiImageGeneratorGrain : Grain, IMultiImageGeneratorGrain
         _multiImageGenerationState = multiImageGenerationState;
         _logger = logger;
     }
+    
+    private ImageGenerationStatus GetCurrentImageGenerationStatus()
+    {
+        var statusArray = new List<ImageGenerationStatus>();
+        
+        if(_multiImageGenerationState.State.ErrorCode == ImageGenerationErrorCode.content_violation)
+        {
+            _logger.LogInformation($"Computed finalStatus : MultiImageRequest: {_multiImageGenerationState.State.RequestId} failed due to content violation");
+            return ImageGenerationStatus.FailedCompletion;
+        }
+        
+        //get child grain references
+        foreach (var imageGenerationRequestId in _multiImageGenerationState.State.ImageGenerationRequestIds)
+        {
+            //check the imageTracker for imageGenerationRequestId
+            var imageGenerationTracker = _multiImageGenerationState.State.imageGenerationTrackers[imageGenerationRequestId];
 
-    public async Task NotifyImageGenerationStatus(string imageRequestId, ImageGenerationStatus status, string? error)
+            //if the status is not successful, return false
+            // if status is inProgress, break loop and return the Status as InProgress
+            if(imageGenerationTracker.Status == ImageGenerationStatus.InProgress)
+            {
+                return imageGenerationTracker.Status;
+            }
+            
+            statusArray.Add(imageGenerationTracker.Status);
+        }
+        
+        // if all statuses are successful, return true
+        if (statusArray.All(status => status == ImageGenerationStatus.SuccessfulCompletion))
+        {
+            return ImageGenerationStatus.SuccessfulCompletion;
+        }
+        
+        if (statusArray.Any(state => state == ImageGenerationStatus.FailedCompletion))
+        {
+            // loop thru imageGenerationTrackers and check for value of property ErrorCode and if any one is equals to content_violation then set finalStatus as FailedCompletion
+            foreach (var tracker in _multiImageGenerationState.State.imageGenerationTrackers.Values)
+            {
+                if (tracker.ErrorCode == ImageGenerationErrorCode.content_violation)
+                {
+                    return ImageGenerationStatus.FailedCompletion;
+                }
+            }
+        }
+        
+        // else return inProgress
+        return ImageGenerationStatus.InProgress;
+    }
+
+    public async Task NotifyImageGenerationStatus(string imageRequestId, ImageGenerationStatus status, string? error, ImageGenerationErrorCode? imageGenerationErrorCode)
     {
         _logger.LogInformation($"NotifyImageGenerationStatus called with requestId: {imageRequestId}, status: {status}, error: {error}");
 
@@ -33,9 +81,17 @@ public class MultiImageGeneratorGrain : Grain, IMultiImageGeneratorGrain
             Status = status,
             Error = error
         };
+        
+        if (imageGenerationErrorCode == ImageGenerationErrorCode.content_violation)
+        {
+            _multiImageGenerationState.State.ErrorCode = ImageGenerationErrorCode.content_violation;
+        } 
 
         _multiImageGenerationState.State.imageGenerationTrackers[imageGenerationNotification.RequestId] =
             imageGenerationNotification;
+
+        ImageGenerationStatus currentStatus = GetCurrentImageGenerationStatus();
+        _multiImageGenerationState.State.ImageGenerationStatus = currentStatus;
 
         await _multiImageGenerationState.WriteStateAsync();
     }
@@ -112,12 +168,6 @@ public class MultiImageGeneratorGrain : Grain, IMultiImageGeneratorGrain
         catch (Exception ex)
         {
             _logger.LogError(ex, $"Error occurred in GenerateMultipleImagesAsync for MultiImageRequest: {multiImageRequestId}");
-            if (_multiImageGenerationState.State.Errors == null)
-            {
-                _multiImageGenerationState.State.Errors = [];
-            }
-
-            _multiImageGenerationState.State.Errors.Add(ex.Message);
             _multiImageGenerationState.State.IsSuccessful = false;
             await _multiImageGenerationState.WriteStateAsync();
             return new MultiImageGenerationGrainResponse
@@ -126,7 +176,7 @@ public class MultiImageGeneratorGrain : Grain, IMultiImageGeneratorGrain
                 Traits = traits,
                 Prompt = "",
                 IsSuccessful = false,
-                Errors = _multiImageGenerationState.State.Errors
+                Errors =  [ex.Message]
             };
         }
     }
@@ -137,60 +187,7 @@ public class MultiImageGeneratorGrain : Grain, IMultiImageGeneratorGrain
         _multiImageGenerationState.State.Traits = attributes;
         await _multiImageGenerationState.WriteStateAsync();
     }
-
-    public async Task<Dictionary<string, TraitEntry>> lookupTraitDefinitions(List<Attribute> requestTraits)
-    {
-        _logger.LogInformation($"lookupTraitDefinitions called with requestTraits: {requestTraits}");
-        // Extract trait names from the request
-        var traitNames = requestTraits.Select(t => t.TraitType).ToList();
-
-        // Get a reference to the TraitConfigGrain
-        var traitConfigGrain = GrainFactory.GetGrain<ITraitConfigGrain>("traitConfigGrain");
-
-        // Retrieve the trait definitions from the TraitConfigGrain
-        var response = await traitConfigGrain.GetTraitsMap(traitNames);
-
-        return response;
-    }
-
-    private ImageGenerationStatus GetCurrentImageGenerationStatus()
-    {
-        ImageGenerationStatus finalStatus = ImageGenerationStatus.Dormant;
-
-        var statusArray = new List<ImageGenerationStatus>();
-        
-        //get child grain references
-        foreach (var imageGenerationRequestId in _multiImageGenerationState.State.ImageGenerationRequestIds)
-        {
-            //check the imageTracker for imageGenerationRequestId
-            var imageGenerationTracker = _multiImageGenerationState.State.imageGenerationTrackers[imageGenerationRequestId];
-
-            //if the status is not successful, return false
-            // if status is inProgress, break loop and return the Status as InProgress
-            if(imageGenerationTracker.Status == ImageGenerationStatus.InProgress)
-            {
-                return imageGenerationTracker.Status;
-            }
-            
-            statusArray.Add(imageGenerationTracker.Status);
-        }
-        
-        // if all statuses are successful, return true
-        if (statusArray.All(status => status == ImageGenerationStatus.SuccessfulCompletion))
-        {
-            return ImageGenerationStatus.SuccessfulCompletion;
-        }
-        
-        // if all statuses are failed, return false
-        if (statusArray.All(status => status == ImageGenerationStatus.FailedCompletion))
-        {
-            return ImageGenerationStatus.FailedCompletion;
-        }
-        
-        // else return inProgress
-        return ImageGenerationStatus.InProgress;
-    }
-
+    
     public async Task<MultiImageQueryGrainResponse> QueryMultipleImagesAsync()
     {
         _logger.LogInformation($"QueryMultipleImagesAsync called for MultiImageRequest: {_multiImageGenerationState.State.RequestId}");
@@ -214,94 +211,69 @@ public class MultiImageGeneratorGrain : Grain, IMultiImageGeneratorGrain
                 Status = ImageGenerationStatus.InProgress
             };
         }
-
-        var allImages = new List<ImageDescription>();
-        var imageGenerationStates = new List<ImageGenerationStatus>();
-        var errorMessages = new List<string>();
-
-        foreach (var imageGenerationRequestId in _multiImageGenerationState.State.ImageGenerationRequestIds)
+        
+        if(imageGenerationStatus == ImageGenerationStatus.FailedCompletion)
         {
-            _logger.LogInformation($"Querying ImageGeneratorGrain for ImageGenerationRequestId: {imageGenerationRequestId}");
+            _logger.LogInformation($"Some images for MultiImageRequest: {_multiImageGenerationState.State.RequestId} failed to generate");
+
+            var errors = _multiImageGenerationState.State.imageGenerationTrackers
+                .Select(imageGenerationTracker => imageGenerationTracker.Value.Error).ToList();
             
-            var imageGeneratorGrain = GrainFactory.GetGrain<IImageGeneratorGrain>(imageGenerationRequestId);
-
-            var response = await imageGeneratorGrain.QueryImageAsync();
-            
-            _logger.LogInformation($"Query response for ImageGenerationRequestId: {imageGenerationRequestId} is: {response}");
-
-            if (response is not ImageQueryGrainResponse grainResponse)
+            return new MultiImageQueryGrainResponse
             {
-                _logger.LogError($"Query response for ImageGenerationRequestId: {imageGenerationRequestId} is not of type ImageQueryGrainResponse");
-                continue;
-            }
+                Status = ImageGenerationStatus.FailedCompletion,
+                Errors = errors
+            };
+        }
 
-            if (grainResponse.Status == ImageGenerationStatus.SuccessfulCompletion && grainResponse.Image != null)
+        try
+        {
+            var allImages = new List<ImageDescription>();
+
+            foreach (var imageGenerationRequestId in _multiImageGenerationState.State.ImageGenerationRequestIds)
             {
+                _logger.LogInformation(
+                    $"Querying ImageGeneratorGrain for ImageGenerationRequestId: {imageGenerationRequestId}");
+
+                var imageGeneratorGrain = GrainFactory.GetGrain<IImageGeneratorGrain>(imageGenerationRequestId);
+
+                var response = await imageGeneratorGrain.QueryImageAsync();
+
+                _logger.LogInformation(
+                    $"Query response for ImageGenerationRequestId: {imageGenerationRequestId} is: {response}");
+
+                if (response is not { } grainResponse)
+                {
+                    _logger.LogError(
+                        $"Query response for ImageGenerationRequestId: {imageGenerationRequestId} is not of type ImageQueryGrainResponse");
+                    continue;
+                }
+
+                if (grainResponse is not
+                    { Status: ImageGenerationStatus.SuccessfulCompletion, Image: not null }) continue;
                 grainResponse.Image.Attributes = _multiImageGenerationState.State.Traits;
-                imageGenerationStates.Add(grainResponse.Status);
                 allImages.Add(grainResponse.Image);
             }
 
-            else
+            if (allImages.Count != _multiImageGenerationState.State.ImageGenerationRequestIds.Count)
             {
-                imageGenerationStates.Add(response.Status);
+                return new MultiImageQueryGrainResponse {Status = ImageGenerationStatus.FailedCompletion, Errors = ["ImageData not found"]};
             }
-        }
 
-        ImageGenerationStatus finalStatus;
-
-        // loop thru the imageGenerationStates and determine the final status by below logc
-        // if any of the statuses is InProgress, mark the final status as InProgress
-        // if all statuses are SuccessfulCompletion, mark the final status as SuccessfulCompletion
-        // if all statuses are FailedCompletion, mark the final status as FailedCompletion
-        if (imageGenerationStates.Any(state => state == ImageGenerationStatus.InProgress))
-        {
-            _logger.LogInformation($"Computed finalStatus : Some images for MultiImageRequest: {_multiImageGenerationState.State.RequestId} are still in progress");
-            // If any of the statuses is InProgress, mark the final status as InProgress
-            finalStatus = ImageGenerationStatus.InProgress;
-        }
-        else if (imageGenerationStates.All(state => state == ImageGenerationStatus.SuccessfulCompletion))
-        {
-            _logger.LogInformation($"Computed finalStatus : All images for MultiImageRequest: {_multiImageGenerationState.State.RequestId} are generated successfully");
-            // If all statuses are SuccessfulCompletion, mark the final status as SuccessfulCompletion
-            finalStatus = ImageGenerationStatus.SuccessfulCompletion;
-        }
-        else if (imageGenerationStates.All(state => state == ImageGenerationStatus.FailedCompletion))
-        {
-            _logger.LogInformation($"Computed finalStatus : All images for MultiImageRequest: {_multiImageGenerationState.State.RequestId} failed to generate");
-            // If all statuses are FailedCompletion, mark the final status as FailedCompletion
-            finalStatus = ImageGenerationStatus.FailedCompletion;
-        }
-        else
-        {
-            // Handle the case where the statuses are a mix of SuccessfulCompletion and FailedCompletion
-            finalStatus = ImageGenerationStatus.InProgress;
-        }
-
-        if (finalStatus == ImageGenerationStatus.SuccessfulCompletion)
-        {
-            _logger.LogInformation($"All images for MultiImageRequest: {_multiImageGenerationState.State.RequestId} are generated successfully");
+            //prepare MultiImageQueryGrainResponse based on finalStatus computed from imageGenerationTrackers
+            _logger.LogInformation(
+                $"All images for MultiImageRequest: {_multiImageGenerationState.State.RequestId} are generated successfully");
             return new MultiImageQueryGrainResponse
             {
                 Images = allImages,
                 Status = ImageGenerationStatus.SuccessfulCompletion
             };
-        }
-        else if (finalStatus == ImageGenerationStatus.InProgress)
+        } catch (Exception e)
         {
-            _logger.LogInformation($"Some images for MultiImageRequest: {_multiImageGenerationState.State.RequestId} are still in progress");
+            _logger.LogError($"Error occurred in QueryMultipleImagesAsync for MultiImageRequest: {_multiImageGenerationState.State.RequestId}, exception: {e.Message}");
             return new MultiImageQueryGrainResponse
             {
                 Status = ImageGenerationStatus.InProgress
-            };
-        }
-        else
-        {
-            _logger.LogInformation($"Some images for MultiImageRequest: {_multiImageGenerationState.State.RequestId} failed to generate");
-            return new MultiImageQueryGrainResponse
-            {
-                Status = ImageGenerationStatus.FailedCompletion,
-                Errors = errorMessages
             };
         }
     }

--- a/Grains/dalle-image-generator/MultiImageGeneratorState.cs
+++ b/Grains/dalle-image-generator/MultiImageGeneratorState.cs
@@ -18,14 +18,17 @@ public class MultiImageGenerationState
     [Id(3)]
     public bool IsSuccessful { get; set; }
 
-
     [Id(4)]
-    public List<string>? Errors { get; set; }
-
-    [Id(5)]
     public List<string> ImageGenerationRequestIds = [];
-    [Id(6)]
+    
+    [Id(5)]
     public Dictionary<string, ImageGenerationTracker> imageGenerationTrackers = [];
+    
+    [Id(6)]
+    public ImageGenerationStatus ImageGenerationStatus { get; set; }
+    
+    [Id(7)]
+    public ImageGenerationErrorCode? ErrorCode { get; set; }
 }
 
 [GenerateSerializer]
@@ -39,4 +42,7 @@ public class ImageGenerationTracker
 
     [Id(2)]
     public string? Error { get; set; }
+    
+    [Id(3)]
+    public ImageGenerationErrorCode? ErrorCode { get; set; }
 }

--- a/Grains/interfaces/ImageGenerationGrainInterface.cs
+++ b/Grains/interfaces/ImageGenerationGrainInterface.cs
@@ -28,7 +28,7 @@ public interface IMultiImageGeneratorGrain : ISchrodingerGrain, IGrainWithString
 
     Task UpdatePromptAndAttributes(string prompt, List<Attribute> attributes);
 
-    Task NotifyImageGenerationStatus(string imageRequestId, ImageGenerationStatus status, string? error);
+    Task NotifyImageGenerationStatus(string imageRequestId, ImageGenerationStatus status, string? error, ImageGenerationErrorCode? errorCode);
 
     Task<MultiImageQueryGrainResponse> QueryMultipleImagesAsync();
     

--- a/Shared/ImageGenerationAPISchema.cs
+++ b/Shared/ImageGenerationAPISchema.cs
@@ -162,6 +162,10 @@ namespace Shared
         [JsonPropertyName("error")]
         [Id(0)]
         public string Error { get; set; }
+        
+        [JsonPropertyName("errorCode")]
+        [Id(1)]
+        public string ErrorCode { get; set; }
     }
 
     [GenerateSerializer]

--- a/Shared/ImageGenerationConstants.cs
+++ b/Shared/ImageGenerationConstants.cs
@@ -2,6 +2,7 @@ namespace Shared;
 
 public enum ImageGenerationErrorCode
 {
+    None,
     api_call_failed,
     invalid_api_key,
     internal_error,

--- a/Shared/ImageGenerationGrainsResponse.cs
+++ b/Shared/ImageGenerationGrainsResponse.cs
@@ -3,13 +3,10 @@ namespace Shared
     public enum ImageGenerationStatus
     {
         Dormant,
-
         InProgress,
         FailedCompletion,
-
         SuccessfulCompletion,
-
-        ReScheduled
+        Blocked,
     }
 
     [GenerateSerializer]

--- a/Shared/ImageGenerationGrainsResponse.cs
+++ b/Shared/ImageGenerationGrainsResponse.cs
@@ -34,6 +34,8 @@ namespace Shared
 
         [Id(3)]
         public List<string>? Errors { get; set; }
+
+        [Id(4)] public string? ErrorCode { get; set; } = "";
     }
 
     [GenerateSerializer]

--- a/WebApiClient/controllers/MultiImageGeneratorController.cs
+++ b/WebApiClient/controllers/MultiImageGeneratorController.cs
@@ -72,8 +72,12 @@ public class MultiImageGeneratorController : ControllerBase
         if (imageQueryResponse.Uninitialized)
             return StatusCode(404, new ImageQueryResponseNotOk { Error = "Request not found" });
 
+        if (imageQueryResponse.Status == ImageGenerationStatus.FailedCompletion && imageQueryResponse.ErrorCode == ImageGenerationErrorCode.content_violation.ToString())
+            return StatusCode(202, new ImageQueryResponseNotOk { Error = "Image Generation Failed With Content Violation Error", ErrorCode = imageQueryResponse.ErrorCode });
+        
         if (imageQueryResponse.Status != ImageGenerationStatus.SuccessfulCompletion)
             return StatusCode(202, new ImageQueryResponseNotOk { Error = "The result is not ready." });
+        
         var images = imageQueryResponse.Images ?? [];
         return StatusCode(200, new ImageQueryResponseOk { Images = images });
     }


### PR DESCRIPTION
# Content Violation Error Handling

1. Azure or Dalle OpenAI can throw Content-Violation Error in case of unacceptable prompt generated from traits
2. In this case we need to record the ImageGenerationStatus as FailedCompletion and also set thr appropriate image-generation-error-code
3. And call the `ReportFailedImageGenerationRequestAsync` on `SchedulerGrain`
